### PR TITLE
Support NULL in toDB and fromDB

### DIFF
--- a/src/mapper/mapper.ts
+++ b/src/mapper/mapper.ts
@@ -63,7 +63,7 @@ export function toDb<T>(item: T, modelConstructor?: ModelConstructor<T>): Attrib
 
     let attributeValue: Attribute | undefined | null
 
-    if (propertyValue === undefined || propertyValue === null) {
+    if (propertyValue === undefined) {
       // noop ignore because we can't map it
     } else {
       /*
@@ -274,7 +274,7 @@ export function fromDb<T>(attributeMap: Attributes<T>, modelConstructor?: ModelC
       modelValue = fromDbOne(attributeValue)
     }
 
-    if (modelValue !== null && modelValue !== undefined) {
+    if (modelValue !== undefined) {
       Reflect.set(<any>model, propertyMetadata ? propertyMetadata.name : attributeName, modelValue)
     }
   })


### PR DESCRIPTION
Ref: https://github.com/shiftcode/dynamo-easy/issues/285

I noticed that there are types and mappers present in the code base, but the mapper for NULL wasn't being called.

Looking at the mapper code, I see that null/NULL is explicitly caught and bypasses the mapper functions. I believe this is probably an oversight, so I removed it and now I can store and fetch null values.